### PR TITLE
add css reset comments

### DIFF
--- a/css/normalize.css
+++ b/css/normalize.css
@@ -1,5 +1,7 @@
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 
+/* Works as a CSS RESET */
+
 /**
  * 1. Set default font family to sans-serif.
  * 2. Prevent iOS and IE text size adjust after device orientation change,


### PR DESCRIPTION
This adds a comment to the `normalize.css` that helps to indicate that this file is acts as a CSS reset.  This comment is a reminder that this file is targeting styles for consistency across browsers.