### PR TITLE
updated the copyright dates and adjusted social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                  <li><a href="https://twitter.com/BryanHerbert2" target="_blank"><img src="img/twitter.png" alt="Twitter Icon"/></a></li>
                  <li><a href="https://github.com/codeherbert" target="_blank"><img src="img/github.png" alt="Github Icon"/></a></li>
                  <li><a href="https://www.linkedin.com/in/bryan-herbert2" target="_blank"><img src="img/linkedin.png" alt="Linkedin Icon"/></a></li>
-                 <li><a href="https://www.facebook.com/bryan.herbert.102" target="_blank"><img src="img/facebook.png" alt="Facebook Icon"/></a></li>
+                 <!-- <li><a href="https://www.facebook.com/bryan.herbert.102" target="_blank"><img src="img/facebook.png" alt="Facebook Icon"/></a></li> -->
                </ul>
              </div>
              <div class="third-width">
@@ -138,7 +138,7 @@
           </section>
 <!--COPYRIGHT section-->
           <footer id="copyright">
-            <p>Copyright 2019 | Bryan Herbert</p>
+            <p>Copyright 2020 | Bryan Herbert</p>
           </footer>
         </main>
     </body>

--- a/work/index.html
+++ b/work/index.html
@@ -90,7 +90,7 @@
             </section>
         </main>
         <footer id="workpage-copyright">
-            <p>Copyright 2019 | Bryan Herbert</p>     
+            <p>Copyright 2020 | Bryan Herbert</p>     
         </footer>
     </body>
 </html>


### PR DESCRIPTION
Here is an update to adjust the copyright years to be current, as well as updates to the social icons being used.  
In `index.html`, the copyright year is updated to be "2020".  Also, the Facebook link is removed in the footer for the social icons.
In `work/index.html`, the copyright year is also updated to be "2020".