### PR TITLE
adds dynamic year update for copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity=
       "sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-      <script type="text/javascript" src="script.js"></script>
+      
     </head>
     <body>
 <!--HEADER-->
@@ -137,9 +137,10 @@
             </div>
           </section>
 <!--COPYRIGHT section-->
-          <footer id="copyright">
-            <p>Copyright 2020 | Bryan Herbert</p>
+          <footer id="copyright" class="copyright">
+            <p>Copyright <span class="js-current-year">CURRENT</span> | Bryan Herbert</p>
           </footer>
         </main>
+        <script type="text/javascript" src="script.js"></script>
     </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
+// dropdown for mobile nav
 function myFunction() {
-    var mytopnav = document.getElementById("myTopnav");
+    let mytopnav = document.getElementById("myTopnav");
     if (mytopnav.className === "topnav") {
         mytopnav.className += " responsive";
     }
@@ -7,3 +8,11 @@ function myFunction() {
         mytopnav.className = "topnav";
     }
 }
+
+// sets current year for copyright
+let date = new Date().getFullYear().toString();
+let copyrightYear = document.querySelectorAll('.copyright .js-current-year');
+copyrightYearArray = [...copyrightYear];
+copyrightYearArray.forEach(function(element) {
+    element.textContent = date;
+});

--- a/work/index.html
+++ b/work/index.html
@@ -13,7 +13,7 @@
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity=
         "sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-        <script type="text/javascript" src="../script.js"></script>
+        
     </head>
     <body>        
         <header>
@@ -133,9 +133,10 @@
                 </div>
             </section>
         </main>
-        <footer id="workpage-copyright">
-            <p>Copyright 2020 | Bryan Herbert</p>     
+        <footer id="workpage-copyright" class="copyright">
+            <p>Copyright <span class="js-current-year">CURRENT</span> | Bryan Herbert</p>    
         </footer>
+        <script type="text/javascript" src="../script.js"></script>
     </body>
 </html>
 


### PR DESCRIPTION
This adds a dynamic way to update the copyright year in the footer.

In the `index.html` file, as well as the `work/index.html` file, the same updates were made.  The `<script>` tag was moved to the bottom of the `body` in the HTML.  The footer was given a class of `copyright`.  Then the actual copyright year was replaced with a `<span>`, which was given a class name of `js-current-year`.  Inside of this element, a default word "Current" was added as a placeholder, that will be dynamically replaced with the current year.  

In the `script.js` file, a new script was added to produce a dynamic year to use in the copyright of the footer.  A variable `data` retrieves the current year in javascript, and converts it to a string.  Another variable `copyrightYear` targets the `copyright` class, which is the footer, as well as the specific `<span>`  with the class of `js-current-year` that will contain the year.  Another variable `copyrightYearArray` then converts this targeted element, which occurs on both the Home page and the Work page, into an array.  A `forEach` then loops through this array, and updates each of the elements `textContent` to equal the current year held in the `date` variable.  Also in this file, the `let` variable was used for the new script, as well as to update the `var` variable in the other script in this file.