### PR TITLE
added feature to position the nav on desktop as fixed when scrolling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -129,6 +129,27 @@ nav {
   text-align: left;
 }
 
+nav {
+  transition: background 0.8s;
+}
+
+nav.scrolled {
+  background: #0a0a0a;
+  background: #009999;
+  position: fixed;
+  top: 0;
+  height: 48px;
+  width: 100%;
+}
+
+nav.scrolled a {
+  color: #fff;
+}
+
+nav.scrolled a:before {
+  background-color: #fff;
+}
+
 /*****WORK*****/
 
 #work {

--- a/script.js
+++ b/script.js
@@ -16,3 +16,14 @@ copyrightYearArray = [...copyrightYear];
 copyrightYearArray.forEach(function(element) {
     element.textContent = date;
 });
+
+// adds class to fixed nav to be styled
+var navbar = document.querySelector('nav');
+window.onscroll = function() {
+  // pageYOffset 
+  if (window.pageYOffset > 0) {
+    navbar.classList.add('scrolled')
+  } else {
+    navbar.classList.remove('scrolled')
+  }
+};


### PR DESCRIPTION
This adds some CSS and JS to allow the navigation to be positioned atop the screen when the user scrolls on the page.
In the `script.js` file, the `nav` element is selected and set to a variable of `navbar`.  A `window.onscroll` is then used along with a function.  This checks if the scroll on the y axis is greater than 0, and if so it adds the class of `scrolled`.  Otherwise, the `scrolled` class is removed.

In the `css/main.css` file, the `nav` is given a `transition` to make the color change smooth.  The `scrolled` class is then given a `background`, as well as a `fixed` positioning, with appropriate styles as well as a height.  The `a` tag on scroll is then changed to the color of #fff, and the `before` pseudo-class is also set to #fff.