### PR TITLE
fixed slight jumping in navbar when srolling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -130,13 +130,12 @@ nav {
 }
 
 nav {
-  transition: background 0.8s;
+  transition: background 1s;
 }
 
 nav.scrolled {
   background: #0a0a0a;
   background: #009999;
-  position: fixed;
   top: 0;
   height: 48px;
   width: 100%;
@@ -462,12 +461,13 @@ nav.scrolled a:before {
   }
 
   nav {
+    background-color: #7576693d;
     display: inline-block;
     font-size: 1em;
     font-weight: bold;
+    position: fixed;
     text-align: right;
     width: 100%;
-    background-color: #7576693d;
   }
 
   nav ul {
@@ -523,7 +523,7 @@ nav.scrolled a:before {
   } */
 
   header h1 {
-    padding-top: 1%;
+    padding-top: 50px;
   }
 
   #home h2 {
@@ -596,7 +596,7 @@ nav.scrolled a:before {
   }
 
   header h1 {
-    padding: 0;
+    padding: 50px 0 0;
   }
 
   #top-div {

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ copyrightYearArray.forEach(function(element) {
 });
 
 // adds class to fixed nav to be styled
-var navbar = document.querySelector('nav');
+const navbar = document.querySelector('nav');
 window.onscroll = function() {
   // pageYOffset 
   if (window.pageYOffset > 0) {


### PR DESCRIPTION
This fixes a minor issue where the nav was slightly jumping when initially scrolling on the page.
In the `main.css` file, the `fixed` positioning was moved from the `nav.scrolled` class to just the `nav` element.  Then the `header h1` was given a different `padding` to offset and account for the `fixed` nav.  While here, the `nav` style for `transition` was slightly adjusted to last longer.

In the `script.js` file, a change was made to the variable to use `const` syntax to declare the variable for the navigation being selected.