### PR TITLE
reorganizing of projects and headings on portfolio work page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -163,6 +163,10 @@ nav.scrolled a:before {
 
 /*****WORK*****/
 
+#portfolio header h1 {
+  padding-top: 70px;
+}
+
 #work {
   color: #006666;
 }
@@ -547,6 +551,10 @@ nav.scrolled a:before {
     padding: 0.5%;
   }
 
+  #portfolio header h1 {
+    padding-top: 110px;
+  }
+
   #work h2 {
     padding: 6%;
     width: 80%;
@@ -654,6 +662,10 @@ nav.scrolled a:before {
   }
 
   /* ========== WORK PAGE ========== */
+
+  #portfolio header h1 {
+    padding-top: 115px;
+  }
 
   #unplugged-div figure {
     width: 40%;

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <!--WORK section-->
         <section id="work">
           <div class="full-width">
-            <h2>My Portfolio</h2>
+            <h2>Sample Projects</h2>
             <div class="half-width">
               <figure class="work-img">
                 <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank">
@@ -93,7 +93,7 @@
                 as adding new items, marking out items, and deleting items. Go ahead, try it out!</p>
             </div>
           </div>
-          <h3 id="more-link"><a href="http://bryanwesleyherbert.com/work">more</a>
+          <h3 id="more-link"><a href="http://bryanwesleyherbert.com/work">See All</a>
           </h3>
         </section>
 <!--ABOUT section-->

--- a/work/index.html
+++ b/work/index.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         
     </head>
-    <body>        
+    <body id="portfolio">        
         <header>
             <div class="full-width" id="header-wrapper">
                 <div class="topnav" id="myTopnav">
@@ -35,16 +35,68 @@
                     </ul>
                 </nav> 
                 <div id="top-div">
+                    <h1>Portfolio</h1>
                 </div>               
             </div>
             <div id="header-title-work">
-                <h2>More Work<br>
+                <h2>Portfolio<br>
                     Projects
                 </h2>
             </div>
         </header>
         <main>
             <section id="work">
+                <div class="full-width">
+                    <div class="half-width">
+                      <!-- <figure class="work-img">
+                        <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank">
+                          <img src="img/rogue-pickings-final2.png" alt="Rogue Pickings Website"/>
+                        </a>
+                      </figure> -->
+                        <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank">
+                            <figure class="work-img">                            
+                                <img src="../img/rogue-pickings-final2.png" alt="Rogue Pickings Website"/>
+                            </figure>
+                        </a>
+                    </div>
+                    <div class="half-width">
+                        <h3><a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" id="remove-decor">Rogue Pickings Website</a>
+                        </h3>
+                        <h4>Using HTML & CSS, from a Photoshop Design Comp</h4>
+                        <p>This is an accurate reproduction of a page from a sample client site.  I used a PSD to accurately create the webpage,
+                       using a variety of Photoshop tools, HTML and CSS.</p>
+                    </div>
+                </div>
+                <div class="full-width">
+                    <div class="half-width">
+                        <a href="http://bryanwesleyherbert.com/101-code" target="_blank">
+                            <figure class="work-img">                        
+                                <img src="../img/jubilee-final.png" alt="Jubilee Austen Website"/>                        
+                            </figure>
+                        </a>
+                    </div>
+                    <div class="half-width">
+                        <h3><a href="http://bryanwesleyherbert.com/101-code" target="_blank" id="remove-decor">Jubilee Austen Project</a></h3>
+                        <h4>An HTML5 & CSS Website</h4>
+                        <p>I created a website from the ground up, that I was able to set up, code, and launch.  Using HTML5 and CSS, this
+                       incorporates well-organized code with accurate syntax that's validated.</p>
+                    </div>
+                </div>
+                <div class="full-width">
+                    <div class="half-width">
+                        <a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank"></a>
+                            <figure class="work-img">                        
+                                <img src="../img/to-do-list.png" alt="To-Do List App"/>                        
+                            </figure>
+                        </a>
+                    </div>
+                    <div class="half-width">
+                        <h3><a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" id="remove-decor">To-Do List App</h3></a>
+                        <h4>A jQuery, HTML, & CSS Project</h4>
+                        <p >This project is a completely built To-Do List App that incorporates jQuery, as well as all the HTML and CSS. It includes several interactive user features, such 
+                        as adding new items, marking out items, and deleting items. Go ahead, try it out!</p>
+                    </div>
+                </div>
                 <div class="full-width">
                     <div class="half-width" id="unplugged-div">
                         <a href="http://bryanwesleyherbert.com/unplugged-site" target="_blank">


### PR DESCRIPTION
This helped to reorganize the layout of projects on the 'Portfolio' page, so that it includes _all_ projects.  The page was also given a main heading, as well as renaming one of the other headings.

In the main `index.html` file, the `<h2>` above the projects was renamed to "Sample Projects".  This title would help to then allow the projects to be copied over and repeated on the 'Portfolio' page.  Also, the "More" link was renamed to "See All".  

In the `work/index.html` file, the page itself was given a body id of `portfolio`.  The page was given an `<h1>` to display over the banner image, with the text "Portfolio".  Then the entire HTML for the 3 projects on the Homepage was copied over to this 'Portfolio' page.  The 3 projects copied over were: the Rogue Pickings project, the Jubilee Austen project, and the To-Do List App.

In the `main.css` file, some styles were given to the `padding-top` for the `<h1>` that was added to the 'Portfolio' page.  These styles were added for the various screen sizes.