### PR TITLE
adjusts css for sizing of unplugged project image

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -609,6 +609,10 @@ nav.scrolled a:before {
   #lights-out-div {
     clear: both;
   }
+
+  #unplugged-project figure {
+    width: 40%;
+  }
 }
 
 @media only screen and (min-width: 940px) {
@@ -667,11 +671,11 @@ nav.scrolled a:before {
     padding-top: 115px;
   }
 
-  #unplugged-div figure {
-    width: 40%;
+  #unplugged-project figure {
+    width: 32%;
   }
 
-  #lolcat-div figure {
+  #lolcat-project figure {
     width: 40%;
   }
   #work h4 {

--- a/work/index.html
+++ b/work/index.html
@@ -98,8 +98,8 @@
                         as adding new items, marking out items, and deleting items. Go ahead, try it out!</p>
                     </div>
                 </div>
-                <div class="full-width">
-                    <div class="half-width" id="unplugged-div">
+                <div id="unplugged-project" class="full-width">
+                    <div class="half-width">
                         <a href="http://bryanwesleyherbert.com/unplugged-site" target="_blank">
                             <figure class="work-img">
                                 <img src="../img/unplugged.png" alt="Unplugged website"/>
@@ -114,8 +114,8 @@
                             as well as additional pages to click and navigate to.</p>
                     </div>
                 </div>
-                <div class="full-width">
-                    <div class="half-width" id =lolcat-div>
+                <div id="lolcat-project" class="full-width">
+                    <div id="lolcat-div" class="half-width">
                         <a href="http://bryanwesleyherbert.com/lolcat-clock" target="_blank">
                             <figure class="work-img">
                                 <img src="../img/lolcat-clock.png" alt="Lolcat Clock project"/>


### PR DESCRIPTION
In the `work/index.html` file, the `div` with the "Unplugged" project had its id renamed to "unplugged-project". Also, the id was moved to the overall `div` for this project. The project below, which is the "Lolcat" project, also was provided an overall `div` with an id named "lolcat-project".

In the `main.css` file, under the media query for 768px, the `#unplugged-project figure` was given a `width` of "40%". Then a media query is added for 940px, and the  `width` is changed to "32%".  For the `#lolcat-project figure`, it was given the styles that had been assigned to `#lolcat-div figure`.