### PR TITLE
adds a css class to hide text for accessibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -22,6 +22,21 @@ html {
   scroll-behavior: smooth;
 }
 
+.wai {
+  border: 0 !important;
+  border-color: transparent !important;
+  background: transparent !important;
+  position: absolute !important;
+  height: 1px !important;
+  width: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip-path: inset(50%) !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  white-space: nowrap !important;
+}
+
 /*****GRID*****/
 
 #work {


### PR DESCRIPTION
This adds a css class to hide text visually and is intended for accessibility only.

In the `css/main.css` file, a class of `wai` is added. This will force any text with this class to not be seen visually. This is given various properties to accomplish this. It includes a `background` and `border-color` of "transparent", a `position` of "absolute", a `height` and `width` of "1px", an `overflow` of "hidden !important". The `clip-path` and `clip` is set. Other properties are added to help as well.