### PR TITLE
adds noopener noreferrer to additional necessary anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,13 +51,13 @@
             <h2>Sample Projects</h2>
             <div class="half-width">
               <figure class="work-img">
-                <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank">
+                <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" rel="noopener noreferrer">
                   <img src="img/rogue-pickings-final2.png" alt="Rogue Pickings Website"/>
                 </a>
               </figure>
             </div>
             <div class="half-width">
-              <h3><a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" id="remove-decor">Rogue Pickings Website</a></h3>
+              <h3><a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" id="remove-decor" rel="noopener noreferrer">Rogue Pickings Website</a></h3>
               <h4>Using HTML & CSS, from a Photoshop Design Comp</h4>
               <p>This is an accurate reproduction of a page from a sample client site.  I used a PSD to accurately create the webpage,
                using a variety of Photoshop tools, HTML and CSS.</p>
@@ -66,13 +66,13 @@
           <div class="full-width">
             <div class="half-width">
               <figure class="work-img">
-                <a href="https://feedback-app-plus.netlify.app" target="_blank">
+                <a href="https://feedback-app-plus.netlify.app" target="_blank" rel="noopener noreferrer">
                   <img src="img/feedback-app.png" alt="Feedback App"/>
                 </a>
               </figure>
             </div>
             <div class="half-width">
-              <h3><a href="https://feedback-app-plus.netlify.app/" target="_blank" id="remove-decor">Feedback App</a></h3>
+              <h3><a href="https://feedback-app-plus.netlify.app/" target="_blank" id="remove-decor" rel="noopener noreferrer">Feedback App</a></h3>
               <h4>A React Project,<br>
                 Using Components, State, Hooks, Routes, and Context</h4>
               <p>This project is a fully functioning, responsive app that uses the Javascript library React. This app simulates a feedback interface often found on websites. It allows the user to create a review, and select a rating of 1 to 10. By clicking "Send", it's added to the list of comments. There's even a feature to edit or delete your review! Also, by clicking on the "?", you are routed to an About Page that shares information about the app.</p>
@@ -81,13 +81,13 @@
           <div class="full-width">
             <div class="half-width">
               <figure class="work-img">
-                <a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank">
+                <a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" rel="noopener noreferrer">
                   <img src="img/to-do-list.png" alt="To-Do List App"/>
                 </a>
               </figure>
             </div>
             <div class="half-width">
-              <h3><a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" id="remove-decor">To-Do List App</h3></a>
+              <h3><a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" id="remove-decor" rel="noopener noreferrer">To-Do List App</h3></a>
               <h4>A jQuery, HTML, & CSS Project</h4>
               <p >This project is a completely built To-Do List App that incorporates jQuery, as well as all the HTML and CSS. It includes several interactive user features, such 
                 as adding new items, marking out items, and deleting items. Go ahead, try it out!</p>

--- a/work/index.html
+++ b/work/index.html
@@ -51,14 +51,14 @@
             <section id="work">
                 <div class="full-width">
                     <div class="half-width">
-                        <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank">
+                        <a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">                            
                                 <img src="../img/rogue-pickings-final2.png" alt="Rogue Pickings Website"/>
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" id="remove-decor">Rogue Pickings Website</a>
+                        <h3><a href="http://bryanwesleyherbert.com/101-rogue-code" target="_blank" id="remove-decor" rel="noopener noreferrer">Rogue Pickings Website</a>
                         </h3>
                         <h4>Using HTML & CSS, from a Photoshop Design Comp</h4>
                         <p>This is an accurate reproduction of a page from a sample client site.  I used a PSD to accurately create the webpage,
@@ -67,7 +67,7 @@
                 </div>
                 <div class="full-width">
                     <div class="half-width">                      
-                        <a href="https://feedback-app-plus.netlify.app" target="_blank">
+                        <a href="https://feedback-app-plus.netlify.app" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">
                                 <img src="../img/feedback-app.png" alt="Feedback App"/>
                             </figure>
@@ -75,7 +75,7 @@
                       </figure>
                     </div>
                     <div class="half-width">
-                      <h3><a href="https://feedback-app-plus.netlify.app/" target="_blank" id="remove-decor">Feedback App</a></h3>
+                      <h3><a href="https://feedback-app-plus.netlify.app/" target="_blank" id="remove-decor" rel="noopener noreferrer">Feedback App</a></h3>
                       <h4>A React Project,<br>
                         Using Components, State, Hooks, Routes, and Context</h4>
                       <p>This project is a fully functioning, responsive app that uses the Javascript library React. This app simulates a feedback interface often found on websites. It allows the user to create a review, and select a rating of 1 to 10. By clicking "Send", it's added to the list of comments. There's even a feature to edit or delete your review! Also, by clicking on the "?", you are routed to an About Page that shares information about the app.</p>
@@ -83,14 +83,14 @@
                   </div>
                 <div class="full-width">
                     <div class="half-width">
-                        <a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank">
+                        <a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">                        
                                 <img src="../img/to-do-list.png" alt="To-Do List App"/>                        
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" id="remove-decor">To-Do List App</a></h3>
+                        <h3><a href="http://bryanwesleyherbert.com/todo-list-project" target="_blank" id="remove-decor" rel="noopener noreferrer">To-Do List App</a></h3>
                         <h4>A jQuery, HTML, & CSS Project</h4>
                         <p >This project is a completely built To-Do List App that incorporates jQuery, as well as all the HTML and CSS. It includes several interactive user features, such 
                         as adding new items, marking out items, and deleting items. Go ahead, try it out!</p>
@@ -98,14 +98,14 @@
                 </div>
                 <div id="unplugged-project" class="full-width">
                     <div class="half-width">
-                        <a href="http://bryanwesleyherbert.com/unplugged-site" target="_blank">
+                        <a href="http://bryanwesleyherbert.com/unplugged-site" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">
                                 <img src="../img/unplugged.png" alt="Unplugged website"/>
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="http://bryanwesleyherbert.com/unplugged-site" target="_blank" id="remove-decor">Unplugged Website</a></h3>
+                        <h3><a href="http://bryanwesleyherbert.com/unplugged-site" target="_blank" id="remove-decor" rel="noopener noreferrer">Unplugged Website</a></h3>
                         <h4>A Responsive Website,<br>
                             Using HTML5 and CSS</h4>                       
                         <p>This project is a sample website designed to be completely responsive with other devices.  It also includes an embedded responsive map iFrame, 
@@ -114,14 +114,14 @@
                 </div>
                 <div class="full-width">
                     <div class="half-width" id="lights-out-div">
-                        <a href="https://light-puzzle-game.netlify.app/" target="_blank">
+                        <a href="https://light-puzzle-game.netlify.app/" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">
                                 <img src="../img/lights-out.png" alt="Lights Out app"/>
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="https://light-puzzle-game.netlify.app/" target="_blank" id="remove-decor">Lights Out App</a></h3>
+                        <h3><a href="https://light-puzzle-game.netlify.app/" target="_blank" id="remove-decor" rel="noopener noreferrer">Lights Out App</a></h3>
                         <h4>A React Project,<br>
                             Using Components, State, and Events</h4>                       
                         <p>Here is a project that uses the Javascript library React, along with the Create React App utility script, to build out
@@ -133,14 +133,14 @@
                 </div>
                 <div class="full-width">
                     <div class="half-width" id="chee-z-jokes-div">
-                        <a href="https://chee-z-jokes.netlify.app/" target="_blank">
+                        <a href="https://chee-z-jokes.netlify.app/" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">
                                 <img src="../img/chee-z-jokes.png" alt="Chee-z-jokes app"/>
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="https://chee-z-jokes.netlify.app/" target="_blank" id="remove-decor">Chee-Z-Jokes App</a></h3>
+                        <h3><a href="https://chee-z-jokes.netlify.app/" target="_blank" id="remove-decor" rel="noopener noreferrer">Chee-Z-Jokes App</a></h3>
                         <h4>A React Project,<br>
                             Using State, Lifecycle Method, and an API</h4>                       
                         <p>This project is a fully functioning, responsive app that uses the Javascript library React, with the Create React App utility script.  
@@ -152,14 +152,14 @@
                 </div>
                 <div id="lolcat-project" class="full-width">
                     <div id="lolcat-div" class="half-width">
-                        <a href="http://bryanwesleyherbert.com/lolcat-clock" target="_blank">
+                        <a href="http://bryanwesleyherbert.com/lolcat-clock" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">
                                 <img src="../img/lolcat-clock.png" alt="Lolcat Clock project"/>
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="http://bryanwesleyherbert.com/lolcat-clock" target="_blank" id="remove-decor">Lolcat Clock Project</a></h3> 
+                        <h3><a href="http://bryanwesleyherbert.com/lolcat-clock" target="_blank" id="remove-decor" rel="noopener noreferrer">Lolcat Clock Project</a></h3> 
                         <h4>A Javascript Project</h4>                      
                         <p>Here is a project of a working Lolcat Clock that incorporates Javascript. It features 
                             an active clock with dynamically changing images.  It will update based on time of
@@ -168,14 +168,14 @@
                 </div>
                 <div class="full-width">
                     <div class="half-width">
-                        <a href="http://bryanwesleyherbert.com/101-code" target="_blank">
+                        <a href="http://bryanwesleyherbert.com/101-code" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">                        
                                 <img src="../img/jubilee-final.png" alt="Jubilee Austen Website"/>                        
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="http://bryanwesleyherbert.com/101-code" target="_blank" id="remove-decor">Jubilee Austen Project</a></h3>
+                        <h3><a href="http://bryanwesleyherbert.com/101-code" target="_blank" id="remove-decor" rel="noopener noreferrer">Jubilee Austen Project</a></h3>
                         <h4>An HTML5 & CSS Website</h4>
                         <p>I created a website from the ground up, that I was able to set up, code, and launch.  Using HTML5 and CSS, this
                        incorporates well-organized code with accurate syntax that's validated.</p>
@@ -183,14 +183,14 @@
                 </div>
                 <div class="full-width">
                     <div class="half-width" id="decision-div">
-                        <a href="http://bryanwesleyherbert.com/decision-map" target="_blank">
+                        <a href="http://bryanwesleyherbert.com/decision-map" target="_blank" rel="noopener noreferrer">
                             <figure class="work-img">
                                 <img src="../img/decision-map.png" alt="Decision Map"/>
                             </figure>
                         </a>
                     </div>
                     <div class="half-width">
-                        <h3><a href="http://bryanwesleyherbert.com/decision-map" target="_blank" id="remove-decor">U.S. Decision Map</a></h3>
+                        <h3><a href="http://bryanwesleyherbert.com/decision-map" target="_blank" id="remove-decor" rel="noopener noreferrer">U.S. Decision Map</a></h3>
                         <h4>A Javascript Project</h4>
                         <p>This project is an interactive map, as a demonstration of Javascript using multiple concepts.  By hovering 
                                 over a state it will become highlighted, allowing you to track each states results and find out the winner.


### PR DESCRIPTION
This adds the `noopener noreferrer` attribute to any remaining `<a>` tags that open in a new window.

In the `index.html` file, the `<a>` tag for the "Rogue Pickings Website", the "Feedback App", and the "To-Do List App" have the attribute `noopener noreferrer` added.

In the `work/index.html` file, the `<a>` tag for the "Rogue Pickings Website", the "Feedback App", the "To-Do List App", the "Unplugged Website", the  "Lights Out App", the "Chee-Z-Jokes App", the "Lolcat Clock Project", the "Jubilee Austen Project", and the "U.S. Decision Map" have the attribute `noopener noreferrer` added.