### PR TITLE
adds standard meta tag for character encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+      <meta charset="utf-8">
       <!--meta: phone number underline fix- Microsoft Edge browser-->
       <meta name="format-detection" content="telephone=no">
       <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This adds a standard meta tag to the `index.html` file for character encoding. The tag added is: `<meta charset="utf-8">` as a standard practice.